### PR TITLE
let react-native-web build on 'yarn install'

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "lint": "yarn lint:cmd -- babel benchmarks docs jest src",
     "lint:cmd": "eslint --ignore-path .gitignore --fix",
     "precommit": "lint-staged",
+    "prepare": "yarn install --ignore-scripts && yarn compile",
     "release": "yarn lint && yarn test && yarn build && npm publish",
     "test": "flow && jest"
   },


### PR DESCRIPTION
патч, каб пасьля кланіравання garage-mobile-app і запуску yarn больш ня трэба было лазіць асобна ў react-native-web і білдзіць яго.